### PR TITLE
Use require.resolve to load messageformat files

### DIFF
--- a/tasks/locales.js
+++ b/tasks/locales.js
@@ -505,17 +505,13 @@ module.exports = function (grunt) {
             var that = this,
                 dest = this.getDestinationFilePath();
             this.getSourceFiles().forEach(function (file) {
-                grunt.log.writeln("build locale from " + file);
                 var locale = that.getLocaleFromPath(file),
                     destFile = dest.replace(that.options.localePlaceholder, locale),
-                    messages = grunt.file.readJSON(file);
-                grunt.log.writeln("load message format");
-                var messageFormatLocale = that.getMessageFormatLocale(locale);
-                grunt.log.writeln("loaded message format");
-                var messageFormatShared = that.getMessageFormatShared(),
+                    messages = grunt.file.readJSON(file),
+                    messageFormatLocale = that.getMessageFormatLocale(locale),
+                    messageFormatShared = that.getMessageFormatShared(),
                     translationsMap = {},
                     messageFormat = that.messageFormatFactory(locale, messageFormatLocale);
-                grunt.log.writeln("got all files");
                 Object.keys(messages).sort().forEach(function (key) {
                     try {
                         var value = messages[key].value,

--- a/tasks/locales.js
+++ b/tasks/locales.js
@@ -36,9 +36,9 @@ module.exports = function (grunt) {
             // Purge obsolete locale messages by default:
             purgeLocales: true,
             messageFormatLocaleFile:
-                __dirname + '/../node_modules/messageformat/locale/{locale}.js',
+                'messageformat/locale/{locale}.js',
             messageFormatSharedFile:
-                __dirname + '/../node_modules/messageformat/lib/messageformat.include.js',
+                'messageformat/lib/messageformat.include.js',
             localeTemplate: __dirname + '/../i18n.js.tmpl',
             // Allow ftp, http(s), mailto, anchors
             // and messageformat variables (href="{url}"):
@@ -384,6 +384,7 @@ module.exports = function (grunt) {
                 this.options.localePlaceholder,
                 locale.slice(0, 2)
             );
+            file = require.resolve(file);
             if (!grunt.file.exists(file)) {
                 grunt.fail.warn('MessageFormat locale file ' + file.cyan + ' not found.');
                 return this.done();
@@ -393,6 +394,7 @@ module.exports = function (grunt) {
 
         getMessageFormatShared: function () {
             var file = this.options.messageFormatSharedFile;
+            file = require.resolve(file);
             if (!grunt.file.exists(file)) {
                 grunt.fail.warn('MessageFormat shared file ' + file.cyan + ' not found.');
                 return this.done();
@@ -503,13 +505,17 @@ module.exports = function (grunt) {
             var that = this,
                 dest = this.getDestinationFilePath();
             this.getSourceFiles().forEach(function (file) {
+                grunt.log.writeln("build locale from " + file);
                 var locale = that.getLocaleFromPath(file),
                     destFile = dest.replace(that.options.localePlaceholder, locale),
-                    messages = grunt.file.readJSON(file),
-                    messageFormatLocale = that.getMessageFormatLocale(locale),
-                    messageFormatShared = that.getMessageFormatShared(),
+                    messages = grunt.file.readJSON(file);
+                grunt.log.writeln("load message format");
+                var messageFormatLocale = that.getMessageFormatLocale(locale);
+                grunt.log.writeln("loaded message format");
+                var messageFormatShared = that.getMessageFormatShared(),
                     translationsMap = {},
                     messageFormat = that.messageFormatFactory(locale, messageFormatLocale);
+                grunt.log.writeln("got all files");
                 Object.keys(messages).sort().forEach(function (key) {
                     try {
                         var value = messages[key].value,


### PR DESCRIPTION
Loading files from the messageformat module using a realtive path was causing errors. On my setup another module required the messageformat module so it got installed in the root node_modules/ dir, not the one local to grunt-locales. This meant the 'build' task was breaking. Using require.resolve checks parent node_modules directories and fixes this problem.